### PR TITLE
turn off sharrow fastmath for school escort

### DIFF
--- a/ext-configs/school_escorting.yaml
+++ b/ext-configs/school_escorting.yaml
@@ -1,10 +1,7 @@
-# The school escort model as written in this prototype is not
-# compatible with sharrow, so "sharrow_skip" must be activated here.
-# Currently the spec file has a few lines that evaluate differently in
-# the sharrow implementation, resulting in failure that are flagged by
-# the `test` mode.  Once these are fixed (and string comparisons are
-# minimized for performance) this `sharrow_skip` setting can be removed.
-sharrow_skip: true
+# Some data values in the spec file will refer to missing values stored
+# as NaN in the data.  This requires the `sharrow_fastmath` setting to
+# be set to `false` to avoid errors in the sharrow implementation.
+sharrow_fastmath: false
 
 OUTBOUND_SPEC: school_escorting_outbound.csv
 OUTBOUND_COEFFICIENTS: school_escorting_coefficients_outbound.csv


### PR DESCRIPTION
This PR removes the `sharrow_skip` flag on the school escort model, replacing it with `sharrow_fastmath: false`.

This requires also [activitysim/#824](https://github.com/ActivitySim/activitysim/pull/824).